### PR TITLE
PR#49: Added optional `hideSpacingInContent`

### DIFF
--- a/docs/src/guide/gettingStarted/plugins.md
+++ b/docs/src/guide/gettingStarted/plugins.md
@@ -190,6 +190,8 @@ pageType.components = [
     previewInit({ $set }, content) {
       return content;
     },
+    //optional
+    hideSpacingInContent: true,
   },
 ];
 ```


### PR DESCRIPTION
Enabled `hideSpacingInContent` property in component definitions so that in `Content` it will control `spacingClasses` and `whppt-actions` whether or not to hide the default margin/padding and spacing control